### PR TITLE
Improves styling on normal distribution chart 

### DIFF
--- a/app/scripts/analysis/charts/ChartsNormalChart.service.coffee
+++ b/app/scripts/analysis/charts/ChartsNormalChart.service.coffee
@@ -103,7 +103,7 @@ module.exports = class ChartsNormalChart extends BaseService
     topBound = 1 / (standardDerivation * Math.sqrt(Math.PI * 2))
     gaussianCurveData = @getGaussianFunctionPoints(standardDerivation,mean,variance,leftBound,rightBound)
     radiusCoef = 5
-    
+
     padding = 50
     xScale = d3.scale.linear().range([0, width]).domain([leftBound, rightBound])
     yScale = d3.scale.linear().range([height-padding, 0]).domain([bottomBound, topBound])
@@ -113,7 +113,7 @@ module.exports = class ChartsNormalChart extends BaseService
 
     yAxis = d3.svg.axis()
     .scale(yScale)
-    .ticks(10)
+    .ticks(12)
     .tickPadding(0)
     .orient("right")
 
@@ -126,7 +126,7 @@ module.exports = class ChartsNormalChart extends BaseService
     .attr('d', lineGen(gaussianCurveData))
     .data([gaussianCurveData])
     .attr('stroke', 'black')
-    .attr('stroke-width', 2)
+    .attr('stroke-width', 1)
     .on('mousemove', (d) -> showToolTip(getZ(xScale.invert(d3.event.x),mean,standardDerivation).toLocaleString(),d3.event.x,d3.event.y))
     .on('mouseout', (d) -> hideToolTip())
     .attr('fill', "aquamarine")
@@ -141,13 +141,13 @@ module.exports = class ChartsNormalChart extends BaseService
     .attr("class", "y axis")
     .attr("transform", "translate(" + (xScale(mean)) + ",0)")
     .call(yAxis)
-    
+
     # make x y axis thin
     _graph.selectAll('.x.axis path')
     .style({'fill' : 'none', 'stroke' : 'black', 'shape-rendering' : 'crispEdges', 'stroke-width': '1px'})
     _graph.selectAll('.y.axis path')
     .style({'fill' : 'none', 'stroke' : 'black', 'shape-rendering' : 'crispEdges', 'stroke-width': '1px'})
-        
+
 
     _graph.append("svg:g")
     .append("text")      #text label for the x axis
@@ -155,10 +155,17 @@ module.exports = class ChartsNormalChart extends BaseService
     .attr("y", 20  )
     .style("text-anchor", "middle")
     .style("fill", "white")
-    
+
     # rotate text on x axis
     _graph.selectAll('.x.axis text')
     .attr('transform', (d) ->
        'translate(' + this.getBBox().height*-2 + ',' + this.getBBox().height + ')rotate(-40)')
     .style('font-size', '16px')
+
+    # make y axis ticks not intersect with x-axis, ticks on x and y axes
+    # appear to be the same size
+    _graph.selectAll('.y.axis text')
+    .attr('transform', (d) ->
+       'translate(' + (this.getBBox().height*-2-5) + ',' + (this.getBBox().height-30) + ')')
+    .style('font-size', '15.7px')
 

--- a/app/scripts/analysis/charts/ChartsNormalChart.service.coffee
+++ b/app/scripts/analysis/charts/ChartsNormalChart.service.coffee
@@ -126,7 +126,7 @@ module.exports = class ChartsNormalChart extends BaseService
     .attr('d', lineGen(gaussianCurveData))
     .data([gaussianCurveData])
     .attr('stroke', 'black')
-    .attr('stroke-width', 1)
+    .attr('stroke-width', 0)
     .on('mousemove', (d) -> showToolTip(getZ(xScale.invert(d3.event.x),mean,standardDerivation).toLocaleString(),d3.event.x,d3.event.y))
     .on('mouseout', (d) -> hideToolTip())
     .attr('fill', "aquamarine")

--- a/app/scripts/analysis/charts/ChartsPieChart.service.coffee
+++ b/app/scripts/analysis/charts/ChartsPieChart.service.coffee
@@ -43,10 +43,10 @@ module.exports = class ChartsPieChart extends BaseService
         arc.innerRadius(radius-60)
 
       color = d3.scale.category20c()
-      
+
       arcOver = d3.svg.arc()
       .outerRadius(radius + 10)
-      
+
       if not pie # ring chart
         arcOver.innerRadius(radius-50)
 
@@ -57,7 +57,7 @@ module.exports = class ChartsPieChart extends BaseService
       formatted_data = @makePieData data
       sum = @valueSum
       clickOn = (false for [0..formatted_data.length-1])
-     
+
       # PIE ARCS / SLICES
 
       arcs = _graph.selectAll(".arc")
@@ -65,42 +65,42 @@ module.exports = class ChartsPieChart extends BaseService
       .enter()
       .append('g')
       .attr("class", "arc")
-      
+
       paths = arcs.append('path')
       .attr('d', arc)
       .attr('fill', (d) -> color(d.data.value))
       .on('mouseover', handleMouseOver)
       .on('mouseout', handleMouseOut)
       .on('click', handleClick)
-      
+
       # Create Event Handlers for mouse
       handleMouseOver = (d, i) ->
        if clickOn[i] is false
         # Use d3 to select element
         d3.select(this)
-        .attr("stroke","white") 
+        .attr("stroke","white")
         .transition()
         .attr("d", arcOver)
         .attr("stroke-width",3)
-        
+
         # bold the label
         d3.select(this.parentNode)
         .select('text')
         .attr('font-weight', 'bold')
-        
+
       handleMouseOut= (d, i) ->
         if clickOn[i] is false
           d3.select(this)
           .transition()
           .attr('d', arc)
           .attr("stroke", "none")
-          
+
           # unbold the label
           d3.select(this.parentNode)
           .select('text')
           .attr('font-weight', 'normal')
 
-        
+
       handleClick= (d,i) ->
         if clickOn[i] is true
           clickOn[i] = false
@@ -108,12 +108,12 @@ module.exports = class ChartsPieChart extends BaseService
           .transition()
           .attr('d', arc)
           .attr("stroke", 'none')
-          
+
           # unbold the label
           d3.select(this.parentNode)
           .select('text')
           .attr('font-weight', 'normal')
-          
+
         else
           clickOn[i] = true
           d3.select(this)
@@ -121,16 +121,16 @@ module.exports = class ChartsPieChart extends BaseService
           .transition()
           .attr('d', arcOver)
           .attr('stroke', 3)
-          
-          		  
+
+
       arcs.append('path')
       .attr('d', arc)
       .attr('fill', (d) -> color(d.data.value))
       .on('mouseover', handleMouseOver)
       .on('mouseout', handleMouseOut)
       .on('click', handleClick)
-      
-      
+
+
       # Specify where to put text label
       arcs.append('text')
       .attr('class', 'text')
@@ -139,21 +139,25 @@ module.exports = class ChartsPieChart extends BaseService
         x = c[0]
         y = c[1]
         h = Math.sqrt(x*x + y*y)
-        desiredLabelRad = 220
-        'translate(' + (x/h * desiredLabelRad) + ',' + (y/h * desiredLabelRad) + ')'
+        desiredLabelRad = 240
+        left = false
+        if x < 0
+          desiredLabelRad += -.42*x
+          left = true
+        'translate(' + (x/h * desiredLabelRad) + ',' + (y/h * desiredLabelRad - .42*x*left) + ')'
       ).transition()
       .text (d) =>
         d.data.key + ' (' + parseFloat(100 * d.data.value / sum).toFixed(1) + '%)'
       .style('font-size', '16px')
 
-      
-      
-      
-      
-      
-      
-      
 
-      
-      
+
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
- makes line less bold
- has y-axis labels not intersect with x-axis
- also the y-axis labels are a teeny bit smaller so they do not look bigger than the x-axis labels

addresses SOCRAT-ISSUES #67 ( @ https://github.com/SOCR/SOCRAT-issues/issues/67 )

<img width="1212" alt="screen shot 2017-02-08 at 10 48 00 pm" src="https://cloud.githubusercontent.com/assets/17788969/22768507/b5c5329e-ee50-11e6-88e4-8344ac35efa4.png">
